### PR TITLE
Allow specifying a VM name instead of a UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ customLaunchers: {
 In case you want to know the uuids of your vms, you can run `VBoxManage list vms` to get the list of
 available vms.
 
+Or, you can specify the name of the VM returned by `VBoxManage list vms`, e.g.:
+```js
+customLaunchers: {
+    VirtualBoxIE11onWin8: {
+        base: 'VirtualBoxIE11',
+        keepAlive: true,
+        snapshot: 'pristine',
+        vmName: 'IE11 - Win81'
+    }
+}
+```
+
 If you explicitly specify the plugins in your config file as well, make sure to add
 `karma-virtualbox-ie11-launcher` to the list of plugins.
 

--- a/config/grunt/eslint.js
+++ b/config/grunt/eslint.js
@@ -1,7 +1,10 @@
+const grunt = require('grunt');
+
 module.exports = {
     config: {
         options: {
             configFile: 'config/eslint/config.json',
+            fix: grunt.option('fix'),
             reportUnusedDisableDirectives: true
         },
         src: [ '*.js', 'config/**/*.js' ]
@@ -9,6 +12,7 @@ module.exports = {
     src: {
         options: {
             configFile: 'config/eslint/src.json',
+            fix: grunt.option('fix'),
             reportUnusedDisableDirectives: true
         },
         src: [ 'src/**/*.js' ]
@@ -16,6 +20,7 @@ module.exports = {
     test: {
         options: {
             configFile: 'config/eslint/test.json',
+            fix: grunt.option('fix'),
             reportUnusedDisableDirectives: true
         },
         src: [ 'test/**/*.js' ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -384,6 +390,65 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -526,6 +591,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -615,6 +686,12 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-spies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
+      "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -703,6 +780,12 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "coffeescript": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
@@ -788,6 +871,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -2264,6 +2359,23 @@
       "dev": true,
       "requires": {
         "eslint": "^5.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -4605,6 +4717,209 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "rewire": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+      "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.19.1"
+      },
+      "dependencies": {
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+          "dev": true
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
+      }
+    },
     "right-pad": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
@@ -4634,6 +4949,21 @@
       "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
       "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
       "dev": true
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
     },
     "rxjs": {
       "version": "6.3.3",
@@ -5229,6 +5559,12 @@
           }
         }
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@commitlint/cli": "^7.2.1",
     "@commitlint/config-angular": "^7.1.2",
     "chai": "^4.2.0",
+    "chai-spies": "^1.0.0",
     "commitizen": "^3.0.4",
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "^5.7.0",
@@ -27,7 +28,8 @@
     "gruntify-eslint": "^5.0.0",
     "husky": "^1.1.2",
     "load-grunt-config": "^0.19.2",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "rewire": "^4.0.1"
   },
   "engines": {
     "node": ">=8.11.1"

--- a/src/module.js
+++ b/src/module.js
@@ -1,8 +1,7 @@
 const spawn = require('child_process').spawn;
 const spawnargs = require('spawn-args');
 
-// eslint-disable-next-line padding-line-between-statements
-const execute = (command, log) => {
+function execute (command, log) {
     const chunks = [];
     const tokens = command.split(/\s/);
     const shell = spawn(tokens.shift(), spawnargs(tokens.join(' '), { removequotes: 'always' }));
@@ -24,6 +23,10 @@ const execute = (command, log) => {
     });
 
     return new Promise((resolve, reject) => {
+        shell.on('error', (err) => {
+            reject(err);
+        });
+
         shell.on('exit', (code) => {
             if (code === 0) {
                 resolve(chunks.join(''));
@@ -34,19 +37,53 @@ const execute = (command, log) => {
     });
 };
 
+function escapeRegExp (string) {
+    // $& means the whole matched string
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function uuidFromVMName (vmName, uuid, log) {
+    return new Promise((resolve, reject) => {
+        if (uuid) {
+            return resolve(uuid);
+        }
+
+        log.info(`Running 'VBoxManage list vms' to locate installed VM named '${ vmName }'`);
+        execute('VBoxManage list vms', log)
+            .then((result) => {
+                const escapedVmName = escapeRegExp(vmName);
+                // eslint-disable-next-line no-useless-escape
+                const regex = new RegExp(escapedVmName + '.*\{(.+?)\}', 'igm');
+                const m = regex.exec(result);
+
+                if (m && m.length === 2) {
+                    const parsedUuid = m[1];
+
+                    log.info(`Located VM UUID '${ parsedUuid }'`);
+
+                    return resolve(parsedUuid);
+                }
+
+                return reject(new Error(`No virtual machine installed named '${ vmName }'`));
+            })
+            .catch((err) => {
+                return reject(err);
+            });
+    });
+}
+
 function VirtualBoxIE11Browser (args, baseBrowserDecorator, logger) {
     baseBrowserDecorator(this);
 
     const kill = !args.keepAlive;
     const log = logger.create('launcher');
     const snapshot = args.snapshot;
-    const uuid = args.uuid;
 
     // Just override this method to prevent the inherited one to be executed.
     this._start = () => {};
 
-    if (!uuid) {
-        log.error('Please specify the UUID of the virtual machine to use.');
+    if (!args.uuid && !args.vmName) {
+        log.error('Please specify the UUID or name of the virtual machine to use.');
 
         return;
     }
@@ -54,54 +91,67 @@ function VirtualBoxIE11Browser (args, baseBrowserDecorator, logger) {
     this
         .on('kill', (done) => {
             if (kill) {
-                return execute(`VBoxManage controlvm {${ uuid }} acpipowerbutton`, log)
-                    .then(() => done())
-                    .catch(() => {
-                        log.error('Failed to turn of the vitual machine.');
+                uuidFromVMName(args.vmName, args.uuid, log)
+                    .then((uuid) => {
+                        return execute(`VBoxManage controlvm {${ uuid }} acpipowerbutton`, log)
+                            .then(() => done())
+                            .catch(() => {
+                                log.error('Failed to turn of the vitual machine.');
 
-                        done();
+                                done();
+                            });
+                    })
+                    .catch((err) => {
+                        log.error(err);
                     });
             }
 
             done();
         })
         .on('start', (url) => {
-            execute('VBoxManage list runningvms', log)
-                .then((result) => {
-                    if (!result.includes(`{${ uuid }}`)) {
-                        let queue;
+            uuidFromVMName(args.vmName, args.uuid, log)
+                .then((uuid) => {
+                    return execute('VBoxManage list runningvms', log)
+                        .then((result) => {
+                            if (!result.includes(`{${ uuid }}`)) {
+                                let queue;
 
-                        if (snapshot === undefined) {
-                            queue = Promise.resolve();
-                        } else {
-                            queue = execute(`VBoxManage snapshot {${ uuid }} restore "${ snapshot }"`, log);
-                        }
+                                if (snapshot === undefined) {
+                                    queue = Promise.resolve();
+                                } else {
+                                    queue = execute(`VBoxManage snapshot {${ uuid }} restore "${ snapshot }"`, log);
+                                }
 
-                        return queue
-                            .then(() => execute(`VBoxManage startvm {${ uuid }}`, log))
-                            // Wait for the LoggedInUsers to become 0.
-                            .then(() => execute(`VBoxManage guestproperty wait {${ uuid }} /VirtualBox/GuestInfo/OS/LoggedInUsers --timeout 1800000`, log))
-                            // Wait for the LoggedInUsers to become 1.
-                            .then(() => execute(`VBoxManage guestproperty wait {${ uuid }} /VirtualBox/GuestInfo/OS/LoggedInUsers --timeout 1800000`, log))
-                            .then(() => new Promise((resolve) => {
-                                // Wait one more minute to be sure that Windows is up and running.
-                                setTimeout(resolve, 60e3);
-                            }));
-                    }
+                                return queue
+                                    .then(() => execute(`VBoxManage startvm {${ uuid }}`, log))
+                                    // Wait for the LoggedInUsers to become 0.
+                                    .then(() => execute(`VBoxManage guestproperty wait {${ uuid }} /VirtualBox/GuestInfo/OS/LoggedInUsers --timeout 1800000`, log))
+                                    // Wait for the LoggedInUsers to become 1.
+                                    .then(() => execute(`VBoxManage guestproperty wait {${ uuid }} /VirtualBox/GuestInfo/OS/LoggedInUsers --timeout 1800000`, log))
+                                    .then(() => new Promise((resolve) => {
+                                        // Wait one more minute to be sure that Windows is up and running.
+                                        setTimeout(resolve, 60e3);
+                                    }));
+                            }
 
-                    log.info('The virtual machine is already running.');
-                })
-                .then(() => {
-                    return execute(`VBoxManage guestcontrol {${ uuid }} --password Passw0rd! --username IEUser run --exe "C:\\Program Files\\Internet Explorer\\iexplore.exe" --wait-stderr --wait-stdout -- -extoff -private ${ url.replace(/localhost:/, '10.0.2.2:') }`, log);
+                            log.info('The virtual machine is already running.');
+                        })
+                        .then(() => {
+                            return execute(`VBoxManage guestcontrol ${ uuid } --password Passw0rd! --username IEUser run --exe "C:\\Program Files\\Internet Explorer\\iexplore.exe" --wait-stderr --wait-stdout -- -extoff -private ${ url.replace(/localhost:/, '10.0.2.2:') }`, log);
+                        })
+                        .catch((err) => {
+                            if (err === 1) {
+                                log.error('Failed to start Microsoft Internet Explorer.');
+                            } else {
+                                log.error(err);
+                            }
+                        });
                 })
                 .catch((err) => {
-                    if (err === 1) {
-                        log.error('Failed to start Microsoft Internet Explorer.');
-                    } else {
-                        log.error(err);
-                    }
+                    log.error(err);
                 });
         });
+
 }
 
 VirtualBoxIE11Browser.prototype.name = 'VirtualBoxIE11';

--- a/test/unit/module.js
+++ b/test/unit/module.js
@@ -1,4 +1,11 @@
+const chai = require('chai'),
+    rewire = require('rewire'),
+    spies = require('chai-spies');
+
+chai.use(spies);
+const expect = chai.expect;
 const virtualBoxIE11Launcher = require('../../src/module.js');
+const rewiredLauncher = rewire('../../src/module.js');
 
 describe('karma-virtualbox-ie11-launcher', () => {
 
@@ -6,4 +13,103 @@ describe('karma-virtualbox-ie11-launcher', () => {
         expect(virtualBoxIE11Launcher['launcher:VirtualBoxIE11']).to.not.be.undefined;
     });
 
+    describe('#uuidFromVMName', () => {
+        const uuidFromVMName = rewiredLauncher.__get__('uuidFromVMName');
+        const execute = rewiredLauncher.__get__('execute');
+        const log = {
+            error: () => {},
+            info: () => {},
+            warn: () => {}
+        };
+
+        it('should return the uuid when uuid already provided', (done) => {
+            const executeSpy = chai.spy(execute);
+
+            uuidFromVMName('IE11 - Win81', 'c9b3b190-bd7d-41ef-a788-787f5ebc9099', null)
+                .then((result) => {
+                    expect(result).to.eq('c9b3b190-bd7d-41ef-a788-787f5ebc9099');
+                    expect(executeSpy).to.not.have.been.called();
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
+        });
+
+        it('should fail when VirtualBox is not installed', (done) => {
+            rewiredLauncher.__set__('execute', (command, logger) => {
+                return execute('xxxVBoxManage list vms', logger);
+            });
+            uuidFromVMName('IE11 - Win81', null, log)
+                .then((result) => {
+                    done(new Error('uuidFromVMName should have failed, but it returned ' + result));
+                })
+                .catch((err) => {
+                    expect(err).to.not.be.null;
+                    rewiredLauncher.__set__('execute', execute);
+                    done();
+                });
+        });
+
+        it('should fail when no VM available by given name', (done) => {
+            rewiredLauncher.__set__('execute', () => {
+                return new Promise((resolve) => {
+                    resolve('"IE11 - Win81" {c9b3b190-bd7d-41ef-a788-787f5ebc9099}\n"MSEdge - Win10" {8c04d25b-53da-46db-9f91-5f6951bd6846}');
+                });
+            });
+            uuidFromVMName('pancakes', null, log)
+                .then((result) => {
+                    done(new Error('uuidFromVMName should not have returned ' + result));
+                })
+                .catch((err) => {
+                    expect(err).to.not.be.null;
+                    rewiredLauncher.__set__('execute', execute);
+                    done();
+                });
+        });
+
+        it('should succed when VM available by given name', (done) => {
+            rewiredLauncher.__set__('execute', () => {
+                return new Promise((resolve) => {
+                    resolve('"IE11 - Win81" {c9b3b190-bd7d-41ef-a788-787f5ebc9099}\n"MSEdge - Win10" {8c04d25b-53da-46db-9f91-5f6951bd6846}');
+                });
+            });
+            uuidFromVMName('IE11 - Win81', null, log)
+                .then((result) => {
+                    expect(result).to.eq('c9b3b190-bd7d-41ef-a788-787f5ebc9099');
+                    rewiredLauncher.__set__('execute', execute);
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
+        });
+
+        it('should succed when VM available by partial match of given name', (done) => {
+            rewiredLauncher.__set__('execute', () => {
+                return new Promise((resolve) => {
+                    resolve('"IE11 - Win81" {c9b3b190-bd7d-41ef-a788-787f5ebc9099}\n"MSEdge - Win10" {8c04d25b-53da-46db-9f91-5f6951bd6846}');
+                });
+            });
+            uuidFromVMName('Edge', null, log)
+                .then((result) => {
+                    expect(result).to.eq('8c04d25b-53da-46db-9f91-5f6951bd6846');
+                    rewiredLauncher.__set__('execute', execute);
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
+        });
+
+        it('should return first VM when multiple matches found', (done) => {
+            rewiredLauncher.__set__('execute', () => {
+                return new Promise((resolve) => {
+                    resolve('"IE11 - Win81" {c9b3b190-bd7d-41ef-a788-787f5ebc9099}\n"MSEdge - Win10" {8c04d25b-53da-46db-9f91-5f6951bd6846}');
+                });
+            });
+            uuidFromVMName('Win', null, log)
+                .then((result) => {
+                    expect(result).to.eq('c9b3b190-bd7d-41ef-a788-787f5ebc9099');
+                    rewiredLauncher.__set__('execute', execute);
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
+        });
+
+    });
 });


### PR DESCRIPTION
This change allows users to specify the human readable name of a VirtualBox VM in their `karma.conf.js`. I've noticed that the UUID value of a VBox VM isn't consistent after re-importing the same VBox image.
